### PR TITLE
Fix pytest config

### DIFF
--- a/backend/app/apis/stock_info.py
+++ b/backend/app/apis/stock_info.py
@@ -1,0 +1,1 @@
+from ..services.stock_info import StockInfo

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
-testpaths = tests
-pythonpath = .
+testpaths = test
+pythonpath = backend


### PR DESCRIPTION
## Summary
- correct pytest path to `test`
- add backend alias for tests
- provide compatibility shim for `app.apis.stock_info`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yfinance')*

------
https://chatgpt.com/codex/tasks/task_e_684093fbb2348327a19a9ae41a8d2317